### PR TITLE
Correct missing link to alternative councils.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # counciloftims.github.io
+
+1. We hereby recognize the legitimacy of the [Council of
+   Andrews](https://councilofandrews.github.io). We further declare the name
+   Andrew to be quite nice.


### PR DESCRIPTION
Due to some apparent oversight, the establishment of the Council of Andrews has been omitted from official council business. The Council of Andrews seeks to correct this forgivable mistake by the offering of our first pull request.

Good day, sirs. Sincerely,
The Council of Andrews